### PR TITLE
resin-init-flasher: Put board in suspend at the end of flashing

### DIFF
--- a/layers/meta-balena-advantech-ecu1370/recipes-support/resin-init/resin-init-flasher/switch_to_halt.patch
+++ b/layers/meta-balena-advantech-ecu1370/recipes-support/resin-init/resin-init-flasher/switch_to_halt.patch
@@ -14,7 +14,7 @@ Index: 1.0-r2/resin-init-flasher
 -    shutdown -h now
 +    # Turn LP3 on, indicating we finished.
 +    gpioset 4 5=1
-+    halt
++    systemctl suspend
  elif command -v reboot; then
      info "Rebooting..."
      reboot -f


### PR DESCRIPTION
The watchdog timer will reboot the board after 128 seconds even after a halt and this is problematic when using this board as a DUT in an autokit setup, so let's instead put the board in suspend mode which will also disable the watchdog. Going in suspend mode makes the ethernet carrier disabled as expected so the autokit worker will now correctly detect that the DUT has been successfully provisioned.

Changelog-entry: Get the board to enter suspend mode at the end of flashing